### PR TITLE
Delegation Identification Update - Constrained + RBCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,8 +632,8 @@ C:\> StandIn.exe --delegation
 
 [?] Found 3 object(s) with unconstrained delegation..
 
-[*] SamAccountName           : M-2019-05$
-    DistinguishedName        : CN=M-2019-05,OU=Servers,OU=OCCULT,DC=main,DC=redhook,DC=local
+[*] SamAccountName           : M-2019-03$
+    DistinguishedName        : CN=M-2019-03,OU=Servers,OU=OCCULT,DC=main,DC=redhook,DC=local
     userAccountControl       : WORKSTATION_TRUST_ACCOUNT, TRUSTED_FOR_DELEGATION
 
 [*] SamAccountName           : M-W16-DC01$
@@ -644,18 +644,31 @@ C:\> StandIn.exe --delegation
     DistinguishedName        : CN=M-W19-DC01,OU=Domain Controllers,DC=main,DC=redhook,DC=local
     userAccountControl       : SERVER_TRUST_ACCOUNT, TRUSTED_FOR_DELEGATION
 
-[?] Found 1 object(s) with constrained delegation..
+[?] Found 2 object(s) with constrained delegation..
 
-[*] SamAccountName           : M-2019-06$
-    DistinguishedName        : CN=M-2019-06,OU=Servers,OU=OCCULT,DC=main,DC=redhook,DC=local
-    msDS-AllowedToDelegateTo : ldap/m-w16-dc01.main.redhook.local/main.redhook.local
-                               ldap/m-w16-dc01.main.redhook.local
-                               ldap/M-W16-DC01
-                               ldap/m-w16-dc01.main.redhook.local/MAIN
-                               ldap/M-W16-DC01/MAIN
-                               ldap/m-w16-dc01.main.redhook.local/DomainDnsZones.main.redhook.local
-                               ldap/m-w16-dc01.main.redhook.local/ForestDnsZones.main.redhook.local
+[*] SamAccountName           : M-2019-04$
+    DistinguishedName        : CN=M-2019-04,OU=Servers,OU=OCCULT,DC=main,DC=redhook,DC=local
+    msDS-AllowedToDelegateTo : HOST/m-w16-dc01.main.redhook.local/main.redhook.local
+                               HOST/m-w16-dc01.main.redhook.local
+                               HOST/M-W16-DC01
+                               HOST/m-w16-dc01.main.redhook.local/MAIN
+                               HOST/M-W16-DC01/MAIN
+    Protocol Transition      : False
+    userAccountControl       : WORKSTATION_TRUST_ACCOUNT
+
+[*] SamAccountName           : M-2019-05$
+    DistinguishedName        : CN=M-2019-05,OU=Servers,OU=OCCULT,DC=main,DC=redhook,DC=local
+    msDS-AllowedToDelegateTo : cifs/m-2012r2-03.main.redhook.local
+                               cifs/M-2012R2-03
+    Protocol Transition      : True
     userAccountControl       : WORKSTATION_TRUST_ACCOUNT, TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
+
+[?] Found 1 object(s) with resource-based constrained delegation..
+
+[*] SamAccountName           : M-10-1909-01$
+    DistinguishedName        : CN=M-10-1909-01,OU=Workstations,OU=OCCULT,DC=main,DC=redhook,DC=local
+    Inbound Delegation       : Server Admins [GROUP]
+    userAccountControl       : WORKSTATION_TRUST_ACCOUNT
 ```
 
 ## DC's

--- a/README.md
+++ b/README.md
@@ -615,15 +615,15 @@ C:\> StandIn.exe --spn
     Supported ETypes       : RC4_HMAC_DEFAULT
 ```
 
-## Unconstrained / constrained delegation
+## Unconstrained / constrained / resource-based constrained delegation
 
 #### Use Case
 
-> *This function enumerates all accounts that are permitted to perform [unconstrained](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/domain-compromise-via-unrestricted-kerberos-delegation) or [constrained](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation) delegation. These assets can be used to expand access or achieve objectives.*
+> *This function enumerates all accounts that are permitted to perform [unconstrained](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/domain-compromise-via-unrestricted-kerberos-delegation), [constrained](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/abusing-kerberos-constrained-delegation), or [resource-based constrained](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-computer-object-take-over-and-privilged-code-execution) delegation. These assets can be used to expand access or achieve objectives.*
 
 #### Syntax
 
-Return all accounts that have either unconstrained or consrtained delegation permissions.
+Return all accounts that have either unconstrained or constrained delegation permissions, or have inbound resource-based constrained delegation privileges.
 
 ```
 C:\> StandIn.exe --delegation

--- a/StandIn/StandIn/Program.cs
+++ b/StandIn/StandIn/Program.cs
@@ -1100,7 +1100,7 @@ namespace StandIn
             }
 
             // Constrained delegation filter
-            ds.Filter = "(&(userAccountControl:1.2.840.113556.1.4.803:=16777216)(msDS-AllowedToDelegateTo=*)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
+            ds.Filter = "(&(msDS-AllowedToDelegateTo=*)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
 
             // Enum
             try
@@ -1125,10 +1125,103 @@ namespace StandIn
                             if (iDelegateCount == 0)
                             {
                                 Console.WriteLine("    msDS-AllowedToDelegateTo : " + oColl);
-                            } else
+                            }
+                            else
                             {
                                 Console.WriteLine("                               " + oColl);
                             }
+                            iDelegateCount += 1;
+                        }
+                        if (((int)mde.Properties["userAccountControl"].Value & (int)hStandIn.USER_ACCOUNT_CONTROL.TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION) > 0)
+                        {
+                            Console.WriteLine("    Protocol Transition      : True");
+                        }
+                        else
+                        {
+                            Console.WriteLine("    Protocol Transition      : False");
+                        }
+                        Console.WriteLine("    userAccountControl       : " + (hStandIn.USER_ACCOUNT_CONTROL)omProps["useraccountcontrol"][0]);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine("[!] Failed to enumerate DirectoryEntry properties..");
+                        if (ex.InnerException != null)
+                        {
+                            Console.WriteLine("    |_ " + ex.InnerException.Message);
+                        }
+                        else
+                        {
+                            Console.WriteLine("    |_ " + ex.Message);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("[!] Failed to enumerate accounts..");
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine("    |_ " + ex.InnerException.Message);
+                }
+                else
+                {
+                    Console.WriteLine("    |_ " + ex.Message);
+                }
+            }
+
+            // Resource-Based Constrained delegation filter
+            ds.Filter = "(&(msDS-AllowedToActOnBehalfOfOtherIdentity=*)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
+
+            // Enum  
+            try
+            {
+                // Search
+                SearchResultCollection oObject = ds.FindAll();
+                Console.WriteLine("\n[?] Found " + oObject.Count + " object(s) with resource-based constrained delegation..");
+
+                // For each account that has rbcd configured on it pointing to other objects
+                foreach (SearchResult sr in oObject)
+                {
+                    try
+                    {
+                        DirectoryEntry mde = sr.GetDirectoryEntry();
+                        ResultPropertyCollection omProps = sr.Properties;
+
+                        Console.WriteLine("\n[*] SamAccountName           : " + omProps["samAccountName"][0].ToString());
+                        Console.WriteLine("    DistinguishedName        : " + omProps["distinguishedName"][0].ToString());
+
+
+                        string searchFilter = "(&(|";
+                        RawSecurityDescriptor rsd = new RawSecurityDescriptor((byte[])omProps["msDS-AllowedToActOnBehalfOfOtherIdentity"][0], 0);
+                        //get the ACE for each entry in the object's DACL, each of which points to an object that has inbound RBCD privileges.  Used to build a new search query
+                        foreach (System.Security.AccessControl.CommonAce ace in rsd.DiscretionaryAcl)
+                        {
+                            searchFilter = searchFilter + "(objectSid=" + ace.SecurityIdentifier.ToString() + ")";
+                        }
+                        searchFilter = searchFilter + ")(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
+
+                        ds.Filter = searchFilter;
+                        SearchResultCollection delegationObjs = ds.FindAll();
+
+                        UInt32 iDelegateCount = 0;
+                        string group = "";
+                        //parse the results of the search query to get the name of each object that has inbound RBCD privileges on the current object
+                        foreach (SearchResult delegationObj in delegationObjs)
+                        {
+                            omProps = delegationObj.Properties;
+                            if (omProps.Contains("grouptype"))
+                            {
+                                group = " (group obj)";
+                            }
+                            if (iDelegateCount == 0)
+                            {
+                                Console.WriteLine("    Inbound Delegation       : " + omProps["samAccountName"][0].ToString() + group);
+                            }
+                            else
+                            {
+                                Console.WriteLine("                               " + omProps["samAccountName"][0].ToString() + group);
+                            }
+                            group = "";
                             iDelegateCount += 1;
                         }
                         Console.WriteLine("    userAccountControl       : " + (hStandIn.USER_ACCOUNT_CONTROL)omProps["useraccountcontrol"][0]);


### PR DESCRIPTION
Really awesome tool overall!  I Updated the constrained delegation functionality to grab both constrained with / without protocol transition, and added some verbosity to the output to detail which was identified.  Also added code to pull all RBCD relationships on the domain.  

The current constrained delegation LDAP filter includes UAC 16777216 (TRUSTED_TO_AUTH_FOR_DELEGATION), meaning any instances of constrained delegation that are not configured for protocol transition will not be listed.  Also noted that the tool only pulled unconstrained / constrained delegation relationships.  RBCD relationships are a bit different from other forms of delegation as the trust is inbound instead of outbound, but when identified in environments can still be a valid path to compromise, so added a few additional lines to grab the necessary info.

Example before / after output from PR:

Before:
...
[?] Found 1 object(s) with constrained delegation..

[*] SamAccountName           : httpDelegUser
    DistinguishedName        : CN=httpDelegUser,CN=Users,DC=testlab,DC=local
    msDS-AllowedToDelegateTo : www/server02.testlab.local
                               WWW/SERVER02
    userAccountControl       : NORMAL_ACCOUNT, DONT_EXPIRE_PASSWD, TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION





After:
...
[?] Found 2 object(s) with constrained delegation..

[*] SamAccountName           : httpDelegUser
    DistinguishedName        : CN=httpDelegUser,CN=Users,DC=testlab,DC=local
    msDS-AllowedToDelegateTo : www/server02.testlab.local
                               WWW/SERVER02
    Protocol Transition      : True
    userAccountControl       : NORMAL_ACCOUNT, DONT_EXPIRE_PASSWD, TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION

[*] SamAccountName           : a1$
    DistinguishedName        : CN=a1,CN=Computers,DC=testlab,DC=local
    msDS-AllowedToDelegateTo : HTTP/Server03.testlab.local
    Protocol Transition      : False
    userAccountControl       : PASSWD_NOTREQD, WORKSTATION_TRUST_ACCOUNT

[?] Found 2 object(s) with resource-based constrained delegation..

[*] SamAccountName           : SERVER02$
    DistinguishedName        : CN=SERVER02,CN=Computers,DC=testlab,DC=local
    Inbound Delegation       : Domain Users (group obj)
                               Domain Computers (group obj)
                               httpDelegUser
                               rbcdTest123$
                               a1$
                               a2$
                               rbcdTest$
    userAccountControl       : PASSWD_NOTREQD, WORKSTATION_TRUST_ACCOUNT

[*] SamAccountName           : a2$
    DistinguishedName        : CN=a2,CN=Computers,DC=testlab,DC=local
    Inbound Delegation       : Domain Computers (group obj)
                               a1$
    userAccountControl       : PASSWD_NOTREQD, WORKSTATION_TRUST_ACCOUNT