### PR TITLE
Add/Remove SPN feature

### DIFF
--- a/StandIn/StandIn/hStandIn.cs
+++ b/StandIn/StandIn/hStandIn.cs
@@ -147,6 +147,14 @@ namespace StandIn
                               "StandIn.exe --spn\n" +
                               "StandIn.exe --spn --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
 
+                              "# Add a SPN to a user\n" +
+                              "StandIn.exe --object samaccountname=HArmitage --spn --add --sPrincipalName MSSQL/Dataleak\n" +
+                              "StandIn.exe --object samaccountname=FMorgan --spn --add --sPrincipalName MSSQL/Dataleak --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
+
+                              "# Remove a SPN from a user\n" +
+                              "StandIn.exe --object samaccountname=HArmitage --spn --remove --sPrincipalName MSSQL/Dataleak\n" +
+                              "StandIn.exe --object samaccountname=FMorgan --spn --remove --sPrincipalName MSSQL/Dataleak --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
+
                               "# List all accounts with unconstrained & constrained delegation privileges\n" +
                               "StandIn.exe --delegation\n" +
                               "StandIn.exe --delegation --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +


### PR DESCRIPTION
Pull Request to add a feature that helps to realize targeted kerberoasting.
The feature add a `--sPrincipalName` flag to pass the ServicePrincipalName to add or remove.

To add a spn, the user has to target an existing object with `--spn` and `--add` flags:
![Capture d’écran 2021-04-15 à 23 02 45](https://user-images.githubusercontent.com/11190755/116301835-c49a8900-a7a0-11eb-8676-f9bae4e0ff68.png)

To remove a spn, the user has to target an existing object with `--spn` and `--remove` flags:
![Capture d’écran 2021-04-15 à 23 04 03](https://user-images.githubusercontent.com/11190755/116301951-e5fb7500-a7a0-11eb-9599-31c5944b8576.png)

I also modified the `--spn` command to show the different ServicePrincipalName, and not only the first one.

For the moment i did not add example to the README.md ^^
