### PR TITLE
Feature that lookup for  passwdnotreqd accounts

### DIFF
--- a/StandIn/StandIn/hStandIn.cs
+++ b/StandIn/StandIn/hStandIn.cs
@@ -151,6 +151,10 @@ namespace StandIn
                               "StandIn.exe --delegation\n" +
                               "StandIn.exe --delegation --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
 
+                              "# Get a list of all accounts that do not require a password\n" +
+                              "StandIn.exe --passwordnotreqd\n" +
+                              "StandIn.exe --passwordnotreqd --domain redhook --user RFludd --pass Cl4vi$Alchemi4e\n\n" +
+
                               "# Get a list of all domain controllers\n" +
                               "StandIn.exe --dc\n\n" +
 


### PR DESCRIPTION
Pull request to quickly find the account with the PASSWDNOTREQD attribute set with a new flag `--passwdnotreqd`:

![Capture d’écran 2021-04-27 à 22 19 25](https://user-images.githubusercontent.com/11190755/116307730-fca4ca80-a7a6-11eb-88c7-b6cb567ba496.png)

I made  a mistake in the help with the flag, it is `--passwdnotreqd` and not `--passwordnotreqd`. I also have to change README.md ^^