### PR TITLE
check trust relationships in the current domain

### DIFF
--- a/StandIn/StandIn/Program.cs
+++ b/StandIn/StandIn/Program.cs
@@ -3052,11 +3052,11 @@ namespace StandIn
                 TrustRelationshipInformationCollection  trustsCollection = oDom.GetAllTrustRelationships();
 
                 if (trustsCollection.Count < 1){
-                    Console.WriteLine("[*] There is no trust to display..");
+                    Console.WriteLine("[!] There is no trust to display..");
                 } else {
                     foreach (TrustRelationshipInformation trust in trustsCollection)
                     {
-                        Console.WriteLine("\n[*] Source                    : " + trust.SourceName);
+                        Console.WriteLine("\n[>] Source                    : " + trust.SourceName);
                         Console.WriteLine("    Target                    : " + trust.TargetName);
                         Console.WriteLine("    TrustDirection            : " + trust.TrustDirection);
                         Console.WriteLine("    TrustType                 : " + trust.TrustType);

--- a/StandIn/StandIn/Program.cs
+++ b/StandIn/StandIn/Program.cs
@@ -3038,6 +3038,36 @@ namespace StandIn
             }
         }
 
+         public static void GetADTrustRelationships()
+        {
+            try
+            {
+                Domain oDom = Domain.GetComputerDomain();
+                String sPDC = oDom.PdcRoleOwner.Name;
+                String sDomName = oDom.Name;
+                Console.WriteLine("\n[?] Using DC    : " + sPDC);
+                Console.WriteLine("    |_ Domain   : " + sDomName);
+
+                TrustRelationshipInformationCollection  trustsCollection = oDom.GetAllTrustRelationships();
+
+                if (trustsCollection.Count < 1){
+                    Console.WriteLine("[*] There is no trust to display..");
+                } else {
+                    foreach (TrustRelationshipInformation trust in trustsCollection)
+                    {
+                        Console.WriteLine("\n[*] Source                    : " + trust.SourceName);
+                        Console.WriteLine("    Target                    : " + trust.TargetName);
+                        Console.WriteLine("    TrustDirection            : " + trust.TrustDirection);
+                        Console.WriteLine("    TrustType                 : " + trust.TrustType);
+                    }
+                }
+            }
+            catch
+            {
+                Console.WriteLine("[!] Failed to contact the current domain..");
+            }
+        }
+
         public static void StringToUserOrSID(String sUserId, String sDomain = "", String sUser = "", String sPass = "")
         {
             // Create searcher
@@ -3414,6 +3444,9 @@ namespace StandIn
             [Option(null, "dc")]
             public Boolean bDc { get; set; }
 
+            [Option(null, "trust")]
+            public Boolean bTrust { get; set; }
+
             [Option(null, "remove")]
             public Boolean bRemove { get; set; }
 
@@ -3474,7 +3507,7 @@ namespace StandIn
                 }
                 else
                 {
-                    if (!String.IsNullOrEmpty(ArgOptions.sComp) || !String.IsNullOrEmpty(ArgOptions.sObject) || !String.IsNullOrEmpty(ArgOptions.sGroup) || !String.IsNullOrEmpty(ArgOptions.sLdap) || !String.IsNullOrEmpty(ArgOptions.sSid) || !String.IsNullOrEmpty(ArgOptions.sSetSPN) || ArgOptions.bSPN || ArgOptions.bDelegation || ArgOptions.bAsrep || ArgOptions.bDc || ArgOptions.bGPO || ArgOptions.bDNS || ArgOptions.bPolicy || ArgOptions.bPasswdnotreqd)
+                    if (!String.IsNullOrEmpty(ArgOptions.sComp) || !String.IsNullOrEmpty(ArgOptions.sObject) || !String.IsNullOrEmpty(ArgOptions.sGroup) || !String.IsNullOrEmpty(ArgOptions.sLdap) || !String.IsNullOrEmpty(ArgOptions.sSid) || !String.IsNullOrEmpty(ArgOptions.sSetSPN) || ArgOptions.bSPN || ArgOptions.bDelegation || ArgOptions.bAsrep || ArgOptions.bDc || ArgOptions.bTrust || ArgOptions.bGPO || ArgOptions.bDNS || ArgOptions.bPolicy || ArgOptions.bPasswdnotreqd)
                     {
                         if (!String.IsNullOrEmpty(ArgOptions.sComp))
                         {
@@ -3588,6 +3621,10 @@ namespace StandIn
                         else if (ArgOptions.bDc)
                         {
                             GetADDomainControllers();
+                        }
+                        else if (ArgOptions.bTrust)
+                        {
+                            GetADTrustRelationships();
                         }
                         else if (!String.IsNullOrEmpty(ArgOptions.sLdap))
                         {

--- a/StandIn/StandIn/hStandIn.cs
+++ b/StandIn/StandIn/hStandIn.cs
@@ -203,6 +203,7 @@ namespace StandIn
                               "--delegation    Boolean, list accounts with unconstrained / constrained delegation\n" +
                               "--asrep         Boolean, list ASREP roastable accounts\n" +
                               "--dc            Boolean, list all domain controllers\n" +
+                              "--trust         Boolean, list all trust relationships\n" +
                               "--add           Boolean, context dependent group/spn\n" +
                               "--remove        Boolean, context dependent msDS-AllowedToActOnBehalfOfOtherIdentity/group\n" +
 							  "--make          Boolean, make machine; ms-DS-MachineAccountQuota applies\n" +
@@ -301,6 +302,9 @@ namespace StandIn
 
                               "# Get a list of all domain controllers\n" +
                               "StandIn.exe --dc\n\n" +
+
+                              "# Get a list of all trust relationships in the current domain\n" +
+                              "StandIn.exe --trust\n\n" +
 
                               "# List members of group or list user group membership\n" +
                               "StandIn.exe --group Literarum\n" +


### PR DESCRIPTION
Hey

I just added a small feature to check trust relationships in the current domain using the `--trust` flag:
```
PS C:\Tools> .\StandIn.exe --trust

[?] Using DC    : DC01.intern.dojo.local
    |_ Domain   : intern.dojo.local

[*] Source                    : intern.dojo.local
    Target                    : dojo.local
    TrustDirection            : Bidirectional
    TrustType                 : ParentChild
```