### PR TITLE
Set bind path for DirectorySearcher explicitly (fixes PTT)

### DIFF
--- a/StandIn/StandIn/hStandIn.cs
+++ b/StandIn/StandIn/hStandIn.cs
@@ -448,9 +448,16 @@ namespace StandIn
             DirectoryEntry de = null;
             DirectorySearcher ds = null;
             SearchObject resultObject = new SearchObject();
+
+            string bindPath = "";
+            if (!String.IsNullOrEmpty(sDomain))
+            {
+                bindPath = String.Format("LDAP://{0}", sDomain);
+            }
+
             try
             {
-                de = new DirectoryEntry();
+                de = new DirectoryEntry(bindPath);
                 resultObject.sDC = de.Options.GetCurrentServerName();
                 Console.WriteLine("\n[?] Using DC : " + de.Options.GetCurrentServerName());
                 if (!String.IsNullOrEmpty(sDomain) && !String.IsNullOrEmpty(sUser) && !String.IsNullOrEmpty(sPass))


### PR DESCRIPTION
A simple fix for the `DirectorySearcher` to work with PTT in this PR.

When operating from a sacrificial process with a TGT injected, `DirectorySearcher` fails to enumerate current domain root, but if the domain name is specified, we can pass it to the `DirectoryEntry` constructer which results in a successful bind.

![a](https://github.com/FuzzySecurity/StandIn/assets/23141800/f0897bc0-c0ab-4dcc-a879-446fd08beefb)

@TheWover's PR #6 also solves this, btw.